### PR TITLE
Make BepInEx payload coexist with other mods

### DIFF
--- a/bazaarplusplus-installer/src-tauri/src/services/bepinex/mod.rs
+++ b/bazaarplusplus-installer/src-tauri/src/services/bepinex/mod.rs
@@ -155,22 +155,34 @@ pub fn uninstall_bpp(
         )?;
     }
 
-    // Restore the vanilla bundle BEFORE removing siblings. Call uninstall_trampoline
-    // UNCONDITIONALLY (not gated on is_trampolined): it self-classifies — a no-op
-    // when already vanilla, a restore when a `.orig` exists, and a hard error in the
-    // broken stub-without-backup state. A prior `if is_trampolined().unwrap_or(false)`
-    // gate hid both that documented error (is_trampolined returns false the moment
-    // `.orig` is gone) and any plutil read failure. If this fails, abort so we never
-    // strand a stubbed bundle whose `.orig` we then can't recover. No-op off macOS.
-    trampoline::uninstall_trampoline(game_path)?;
+    let keep_shared_bootstrap = payload::has_third_party_plugins(game_path);
 
-    payload::uninstall_payload(game_path)?;
-    trampoline::remove_launch_mode_marker(game_path)?;
+    // Restore the vanilla bundle only when BPP is the last installed plugin. If
+    // another mod remains, the trampoline / launch options are shared BepInEx
+    // bootstrap state and removing them would disable that mod.
+    if !keep_shared_bootstrap {
+        // Call uninstall_trampoline UNCONDITIONALLY (not gated on is_trampolined):
+        // it self-classifies — a no-op when already vanilla, a restore when a
+        // `.orig` exists, and a hard error in the broken stub-without-backup state.
+        // If this fails, abort so we never strand a stubbed bundle whose `.orig`
+        // we then can't recover. No-op off macOS.
+        trampoline::uninstall_trampoline(game_path)?;
+    }
 
-    #[cfg(target_os = "macos")]
-    {
-        if !_steam_path.trim().is_empty() {
-            crate::services::vdf::clear_launch_options_for_steam(Path::new(&_steam_path))?;
+    if keep_shared_bootstrap {
+        payload::uninstall_payload_preserving_shared_dependencies(game_path)?;
+    } else {
+        payload::uninstall_payload(game_path)?;
+    }
+
+    if !keep_shared_bootstrap {
+        trampoline::remove_launch_mode_marker(game_path)?;
+
+        #[cfg(target_os = "macos")]
+        {
+            if !_steam_path.trim().is_empty() {
+                crate::services::vdf::clear_launch_options_for_steam(Path::new(&_steam_path))?;
+            }
         }
     }
 

--- a/bazaarplusplus-installer/src-tauri/src/services/bepinex/payload.rs
+++ b/bazaarplusplus-installer/src-tauri/src/services/bepinex/payload.rs
@@ -7,6 +7,33 @@ use crate::config::BAZAAR_DATA_DIRECTORY;
 
 pub(super) const BPP_CONFIG_RELATIVE_PATH: &str = "BepInEx/config/BazaarPlusPlus.cfg";
 
+const BPP_PRIVATE_RELATIVE_PATHS: &[&str] = &[
+    BPP_CONFIG_RELATIVE_PATH,
+    "BepInEx/plugins/BazaarPlusPlus.dll",
+    "BepInEx/plugins/BazaarPlusPlus.version",
+    "BepInEx/plugins/BazaarPlusPlus.ModApi.dll",
+    "BepInEx/plugins/BazaarPlusPlus.Storage.dll",
+    "BepInEx/plugins/BazaarPlusPlus.Localization.dll",
+    "BepInEx/plugins/libBppMacAudio.dylib",
+];
+
+const BPP_BUNDLED_DEPENDENCY_RELATIVE_PATHS: &[&str] = &[
+    "BepInEx/plugins/Microsoft.Data.Sqlite.dll",
+    "BepInEx/plugins/SQLitePCLRaw.batteries_v2.dll",
+    "BepInEx/plugins/SQLitePCLRaw.core.dll",
+    "BepInEx/plugins/SQLitePCLRaw.provider.e_sqlite3.dll",
+    "BepInEx/plugins/SixLabors.ImageSharp.dll",
+    "BepInEx/plugins/System.Buffers.dll",
+    "BepInEx/plugins/System.Memory.dll",
+    "BepInEx/plugins/System.Numerics.Vectors.dll",
+    "BepInEx/plugins/System.Text.Encoding.CodePages.dll",
+    "BepInEx/plugins/e_sqlite3.dll",
+    "BepInEx/plugins/libe_sqlite3.dylib",
+    "BepInEx/plugins/ffmpeg",
+    "BepInEx/plugins/ffmpeg.exe",
+    "BepInEx/plugins/ffmpeg-LICENSE.txt",
+];
+
 /// Backoff used between retries when a file/directory removal fails. The first
 /// retry runs immediately, the second after a short pause, and the last after
 /// a longer pause. Windows often releases ERROR_SHARING_VIOLATION holds inside
@@ -228,21 +255,64 @@ pub(crate) fn remove_dir_with_retry(root: &Path) -> RemovalReport {
 }
 
 pub(super) fn uninstall_payload(game_path: &Path) -> Result<(), String> {
-    remove_path_if_exists(&game_path.join("BepInEx"))?;
+    remove_bpp_files(game_path, true)
+}
 
-    #[cfg(target_os = "macos")]
-    {
-        remove_path_if_exists(&game_path.join("run_bepinex.sh"))?;
-        remove_path_if_exists(&game_path.join("libdoorstop.dylib"))?;
+pub(super) fn uninstall_payload_preserving_shared_dependencies(
+    game_path: &Path,
+) -> Result<(), String> {
+    remove_bpp_files(game_path, false)
+}
+
+fn remove_bpp_files(game_path: &Path, remove_bundled_dependencies: bool) -> Result<(), String> {
+    for relative_path in BPP_PRIVATE_RELATIVE_PATHS {
+        remove_path_if_exists(&game_path.join(relative_path))?;
     }
 
-    #[cfg(target_os = "windows")]
-    {
-        remove_path_if_exists(&game_path.join("doorstop_config.ini"))?;
-        remove_path_if_exists(&game_path.join("winhttp.dll"))?;
+    if remove_bundled_dependencies {
+        for relative_path in BPP_BUNDLED_DEPENDENCY_RELATIVE_PATHS {
+            remove_path_if_exists(&game_path.join(relative_path))?;
+        }
     }
+
+    remove_empty_dir_if_exists(&game_path.join("BepInEx/config"))?;
+    remove_empty_dir_if_exists(&game_path.join("BepInEx/plugins"))?;
+    remove_empty_dir_if_exists(&game_path.join("BepInEx"))?;
 
     Ok(())
+}
+
+fn remove_empty_dir_if_exists(path: &Path) -> Result<(), String> {
+    match std::fs::remove_dir(path) {
+        Ok(()) => Ok(()),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(err) if err.kind() == std::io::ErrorKind::DirectoryNotEmpty => Ok(()),
+        Err(err) => Err(format!(
+            "Cannot remove empty directory {}: {err}",
+            path.display()
+        )),
+    }
+}
+
+pub(super) fn has_third_party_plugins(game_path: &Path) -> bool {
+    let plugins_dir = game_path.join("BepInEx/plugins");
+    let Ok(entries) = std::fs::read_dir(&plugins_dir) else {
+        return false;
+    };
+
+    entries.filter_map(Result::ok).any(|entry| {
+        let Ok(relative) = entry.path().strip_prefix(game_path).map(Path::to_path_buf) else {
+            return false;
+        };
+        let relative = relative.to_string_lossy().replace('\\', "/");
+        relative != "BepInEx/plugins/.gitkeep"
+            && !BPP_PRIVATE_RELATIVE_PATHS
+                .iter()
+                .any(|owned| owned.eq_ignore_ascii_case(&relative))
+            && !BPP_BUNDLED_DEPENDENCY_RELATIVE_PATHS
+                .iter()
+                .any(|owned| owned.eq_ignore_ascii_case(&relative))
+    })
 }
 
 pub(super) fn ensure_valid_game_path(game_path: &Path) -> Result<(), String> {
@@ -327,7 +397,7 @@ mod tests {
     }
 
     #[test]
-    fn test_prepare_install_target_cleans_previous_payload() {
+    fn test_prepare_install_target_cleans_previous_bpp_files_only() {
         let tmp = tempfile::tempdir().unwrap();
 
         #[cfg(target_os = "macos")]
@@ -347,19 +417,28 @@ mod tests {
         }
 
         std::fs::write(tmp.path().join("BepInEx/plugins/old.dll"), b"dll").unwrap();
+        std::fs::write(
+            tmp.path().join("BepInEx/plugins/BazaarPlusPlus.dll"),
+            b"bpp",
+        )
+        .unwrap();
 
         prepare_install_target(tmp.path()).unwrap();
 
-        assert!(!tmp.path().join("BepInEx").exists());
+        assert!(tmp.path().join("BepInEx/plugins/old.dll").exists());
+        assert!(!tmp
+            .path()
+            .join("BepInEx/plugins/BazaarPlusPlus.dll")
+            .exists());
         #[cfg(target_os = "macos")]
         {
-            assert!(!tmp.path().join("run_bepinex.sh").exists());
-            assert!(!tmp.path().join("libdoorstop.dylib").exists());
+            assert!(tmp.path().join("run_bepinex.sh").exists());
+            assert!(tmp.path().join("libdoorstop.dylib").exists());
         }
         #[cfg(target_os = "windows")]
         {
-            assert!(!tmp.path().join("doorstop_config.ini").exists());
-            assert!(!tmp.path().join("winhttp.dll").exists());
+            assert!(tmp.path().join("doorstop_config.ini").exists());
+            assert!(tmp.path().join("winhttp.dll").exists());
         }
     }
 
@@ -395,7 +474,7 @@ mod tests {
         backup.restore(tmp.path()).unwrap();
 
         assert!(tmp.path().join("BepInEx/plugins/old.dll").exists());
-        assert!(!tmp.path().join("BepInEx/plugins/new.dll").exists());
+        assert!(tmp.path().join("BepInEx/plugins/new.dll").exists());
         #[cfg(target_os = "macos")]
         assert_eq!(
             std::fs::read(tmp.path().join("run_bepinex.sh")).unwrap(),
@@ -440,7 +519,7 @@ mod tests {
     }
 
     #[test]
-    fn test_uninstall_payload_removes_platform_files() {
+    fn test_uninstall_payload_removes_bpp_files_only() {
         let tmp = tempfile::tempdir().unwrap();
         std::fs::create_dir_all(tmp.path().join("BepInEx/plugins")).unwrap();
         std::fs::write(
@@ -448,6 +527,7 @@ mod tests {
             b"dll",
         )
         .unwrap();
+        std::fs::write(tmp.path().join("BepInEx/plugins/OtherMod.dll"), b"dll").unwrap();
 
         #[cfg(target_os = "macos")]
         {
@@ -463,17 +543,36 @@ mod tests {
 
         uninstall_payload(tmp.path()).unwrap();
 
-        assert!(!tmp.path().join("BepInEx").exists());
+        assert!(!tmp
+            .path()
+            .join("BepInEx/plugins/BazaarPlusPlus.dll")
+            .exists());
+        assert!(tmp.path().join("BepInEx/plugins/OtherMod.dll").exists());
         #[cfg(target_os = "macos")]
         {
-            assert!(!tmp.path().join("run_bepinex.sh").exists());
-            assert!(!tmp.path().join("libdoorstop.dylib").exists());
+            assert!(tmp.path().join("run_bepinex.sh").exists());
+            assert!(tmp.path().join("libdoorstop.dylib").exists());
         }
         #[cfg(target_os = "windows")]
         {
-            assert!(!tmp.path().join("doorstop_config.ini").exists());
-            assert!(!tmp.path().join("winhttp.dll").exists());
+            assert!(tmp.path().join("doorstop_config.ini").exists());
+            assert!(tmp.path().join("winhttp.dll").exists());
         }
+    }
+
+    #[test]
+    fn test_has_third_party_plugins_ignores_bpp_owned_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        let plugins_dir = tmp.path().join("BepInEx/plugins");
+        std::fs::create_dir_all(&plugins_dir).unwrap();
+        std::fs::write(plugins_dir.join("BazaarPlusPlus.dll"), b"dll").unwrap();
+        std::fs::write(plugins_dir.join("Microsoft.Data.Sqlite.dll"), b"dll").unwrap();
+
+        assert!(!super::has_third_party_plugins(tmp.path()));
+
+        std::fs::write(plugins_dir.join("OtherMod.dll"), b"dll").unwrap();
+
+        assert!(super::has_third_party_plugins(tmp.path()));
     }
 
     #[test]


### PR DESCRIPTION
BPP现在似乎在管理整个BepInEx，没有考虑到用户安装其他Mod的情况。BPP安装时候会先移除掉BepInEx目录，这样就可能删除掉用户已经安装的Mod。在卸载时候也有类似的逻辑。

除此之外，BPP在MacOS 27上做了一层兼容层，这解决了MacOS 27的steam启动选项无法插入自定义命令的问题。但是创建的兼容层只为BPP自己服务，所以其他Mod没法利用。

这个PR在以上两点上做了修正，让BPP对其他Mod更友好。