### PR TITLE
Fix collection gallery card previews

### DIFF
--- a/bazaarplusplus-mod/src/BazaarPlusPlus/BazaarPlusPlus.csproj
+++ b/bazaarplusplus-mod/src/BazaarPlusPlus/BazaarPlusPlus.csproj
@@ -227,7 +227,7 @@
         Condition="Exists('$(TargetDir)BazaarPlusPlus.Storage.dll')"
       />
     </ItemGroup>
-    <Delete Files="@(FilesToDelete)" />
+    <Delete Files="@(FilesToDelete)" Condition="'$(BppCleanPluginBeforeCopy)' == 'true'" />
     <Copy
       SourceFiles="$(TargetDir)$(TargetName).dll"
       DestinationFiles="$(GamePath)\BepInEx\plugins\$(TargetName).dll"

--- a/bazaarplusplus-mod/src/BazaarPlusPlus/Game/CollectionPanel/Grid/CollectionCardFactory.cs
+++ b/bazaarplusplus-mod/src/BazaarPlusPlus/Game/CollectionPanel/Grid/CollectionCardFactory.cs
@@ -33,7 +33,7 @@ internal sealed class CollectionCardFactory
 
     public bool ReflectionReady => NativeCardPreviewReflection.SetUpMethod != null;
 
-    public CollectionCardBinding? TryBind(CollectionCardVm vm)
+    public CollectionCardBinding? TryBind(CollectionCardVm vm, Transform? parent = null)
     {
         if (vm == null)
             return null;
@@ -56,7 +56,7 @@ internal sealed class CollectionCardFactory
             vm.Type == ECardType.Skill
                 ? NativeCardPreviewKind.ForSkill()
                 : NativeCardPreviewKind.ForItem(vm.Size);
-        var card = _pool.Take(kind, _parent);
+        var card = _pool.Take(kind, parent ?? _parent);
         if (card == null)
             return null;
 

--- a/bazaarplusplus-mod/src/BazaarPlusPlus/Game/CollectionPanel/Grid/CollectionGridVirtualizer.cs
+++ b/bazaarplusplus-mod/src/BazaarPlusPlus/Game/CollectionPanel/Grid/CollectionGridVirtualizer.cs
@@ -342,15 +342,21 @@ internal sealed class CollectionGridVirtualizer
     {
         var vm = _visible[index];
         var bindStartedAt = _firstWindowDiagnostics?.StartBind(index) ?? 0L;
-        var binding = _factory.TryBind(vm);
+        var container = CreateCellContainer(index);
+        RepositionContainer(index, container);
+        var binding = _factory.TryBind(vm, container);
         _firstWindowDiagnostics?.RecordBind(index, bindStartedAt, binding);
         if (binding == null)
+        {
+            UnityEngine.Object.Destroy(container.gameObject);
             return;
+        }
         var card = binding.Value.Card;
         var rect = card.transform as RectTransform;
         if (rect == null)
         {
             _factory.Return(card, binding.Value.Kind);
+            UnityEngine.Object.Destroy(container.gameObject);
             return;
         }
 
@@ -372,12 +378,26 @@ internal sealed class CollectionGridVirtualizer
             binding.Value.SetUpTask,
             ++_perCellGeneration,
             hover,
-            rect
+            rect,
+            container
         );
         _realized[index] = cell;
         Reposition(index, cell);
         ApplyCellScale(index, cell);
         _ = ShowWhenReady(cell, _generation);
+    }
+
+    private RectTransform CreateCellContainer(int index)
+    {
+        var host = new GameObject($"CollectionPanelCell_{index}", typeof(RectTransform));
+        host.layer = _overlay.BoardRoot != null ? _overlay.BoardRoot.gameObject.layer : host.layer;
+        host.transform.SetParent(_overlay.BoardRoot, worldPositionStays: false);
+        var rect = host.GetComponent<RectTransform>();
+        rect.anchorMin = new Vector2(0f, 1f);
+        rect.anchorMax = new Vector2(0f, 1f);
+        rect.pivot = new Vector2(0.5f, 0.5f);
+        rect.localScale = Vector3.one;
+        return rect;
     }
 
     // Scale the native card to fit its span cell, centered, never stretched. The cell is shrunk
@@ -389,9 +409,9 @@ internal sealed class CollectionGridVirtualizer
             return;
         var cellRect = _layout.ContentRectFor(index, _unit, _gap, _originX, _originY);
         var inset = CollectionGridConstants.CellContentInset;
-        var sizeDelta = rect.sizeDelta;
-        var natW = Mathf.Max(1f, sizeDelta.x);
-        var natH = Mathf.Max(1f, sizeDelta.y);
+        var nativeSize = ResolveNativeCardSize(rect);
+        var natW = Mathf.Max(1f, nativeSize.x);
+        var natH = Mathf.Max(1f, nativeSize.y);
 
         // Scale to the cell HEIGHT so every card in a shelf renders the same height. Native item
         // cards share one prefab height and a shelf shares one cell height, so a height-based
@@ -410,11 +430,26 @@ internal sealed class CollectionGridVirtualizer
         rect.localScale = new Vector3(scale, scale, 1f);
     }
 
+    private static Vector2 ResolveNativeCardSize(RectTransform rect)
+    {
+        var size = rect.sizeDelta;
+        if (size.x > 1f && size.y > 1f)
+            return size;
+
+        var currentRect = rect.rect;
+        if (currentRect.width > 1f && currentRect.height > 1f)
+            return new Vector2(currentRect.width, currentRect.height);
+
+        return new Vector2(420f, 620f);
+    }
+
     private void Reposition(int index, RealizedCell cell)
     {
-        var rect = cell.CachedRect;
-        if (rect == null)
-            return;
+        RepositionContainer(index, cell.ContainerRect);
+    }
+
+    private void RepositionContainer(int index, RectTransform rect)
+    {
         var cellRect = _layout.ContentRectFor(index, _unit, _gap, _originX, _originY);
         var screenTop = cellRect.Y - _scrollY;
         // Board pivot is top-left, so y goes negative. Place card pivot at cell center.
@@ -425,6 +460,7 @@ internal sealed class CollectionGridVirtualizer
             cellRect.X + cellRect.Width * 0.5f,
             -(screenTop + cellRect.Height * 0.5f)
         );
+        rect.sizeDelta = new Vector2(cellRect.Width, cellRect.Height);
     }
 
     // Push the visible window's board-local cell rects to the slot layer. Driven by the layout
@@ -488,6 +524,12 @@ internal sealed class CollectionGridVirtualizer
             return;
         try
         {
+            Reposition(cell.Index, cell);
+            NativeCardPreviewRuntime.Resize(
+                cell.Card,
+                logComponent: "CollectionGridVirtualizer"
+            );
+            ApplyCellScale(cell.Index, cell);
             cell.Card.gameObject.SetActive(true);
             NativeCardPreviewRuntime.Show(
                 cell.Card,
@@ -548,7 +590,11 @@ internal sealed class CollectionGridVirtualizer
     private void CompleteRecycle(RealizedCell cell)
     {
         cell.HoverRelay?.Clear();
+        if (cell.Card != null && _overlay.BoardRoot != null)
+            cell.Card.transform.SetParent(_overlay.BoardRoot, worldPositionStays: false);
         _factory.Return(cell.Card, cell.Kind);
+        if (cell.ContainerRect != null)
+            UnityEngine.Object.Destroy(cell.ContainerRect.gameObject);
     }
 
     private void RecycleAll()
@@ -588,7 +634,8 @@ internal sealed class CollectionGridVirtualizer
             Task setUpTask,
             int generation,
             CollectionCardHoverRelay hoverRelay,
-            RectTransform cachedRect
+            RectTransform cachedRect,
+            RectTransform containerRect
         )
         {
             Index = index;
@@ -599,6 +646,7 @@ internal sealed class CollectionGridVirtualizer
             Generation = generation;
             HoverRelay = hoverRelay;
             CachedRect = cachedRect;
+            ContainerRect = containerRect;
         }
 
         public int Index { get; }
@@ -609,6 +657,7 @@ internal sealed class CollectionGridVirtualizer
         public int Generation { get; }
         public CollectionCardHoverRelay HoverRelay { get; }
         public RectTransform CachedRect { get; }
+        public RectTransform ContainerRect { get; }
         public bool PendingReturn { get; set; }
 
         // Fade state. ShowWhenReady sets FadeActive=true with FadeAlpha=0 right after the

--- a/bazaarplusplus-mod/src/BazaarPlusPlus/GameInterop/CardPreview/NativeCardPreviewPrefabResolver.cs
+++ b/bazaarplusplus-mod/src/BazaarPlusPlus/GameInterop/CardPreview/NativeCardPreviewPrefabResolver.cs
@@ -4,6 +4,8 @@ using System.Reflection;
 using BazaarGameShared.Domain.Core.Types;
 using BazaarPlusPlus.Infrastructure;
 using HarmonyLib;
+using TheBazaar.AppFramework;
+using UnityEngine.AddressableAssets;
 using UnityEngine;
 
 namespace BazaarPlusPlus.GameInterop.CardPreview;
@@ -16,35 +18,46 @@ internal static class NativeCardPreviewPrefabResolver
     private static readonly Dictionary<NativeCardPreviewKind, Component> PrefabRefs = new();
     private static NativeCardPreviewSocketTemplate[]? _socketTemplates;
     private static bool _resolved;
+    private static bool _missingMetadataLogged;
+    private static bool _assetLoaderFailureLogged;
 
     private static readonly System.Type? MonsterBoardTooltipType = AccessTools.TypeByName(
         MonsterBoardTooltipTypeName
     );
 
-    private static readonly FieldInfo? SmallItemReferenceField =
-        MonsterBoardTooltipType != null
-            ? AccessTools.Field(MonsterBoardTooltipType, "_smallItemReference")
-            : null;
+    private static readonly FieldInfo? SmallItemReferenceField = FindMonsterBoardTooltipField(
+        "_smallItemReference"
+    );
 
-    private static readonly FieldInfo? MediumItemReferenceField =
-        MonsterBoardTooltipType != null
-            ? AccessTools.Field(MonsterBoardTooltipType, "_mediumItemReference")
-            : null;
+    private static readonly FieldInfo? MediumItemReferenceField = FindMonsterBoardTooltipField(
+        "_mediumItemReference"
+    );
 
-    private static readonly FieldInfo? LargeItemReferenceField =
-        MonsterBoardTooltipType != null
-            ? AccessTools.Field(MonsterBoardTooltipType, "_largeItemReference")
-            : null;
+    private static readonly FieldInfo? LargeItemReferenceField = FindMonsterBoardTooltipField(
+        "_largeItemReference"
+    );
 
-    private static readonly FieldInfo? SkillReferenceField =
-        MonsterBoardTooltipType != null
-            ? AccessTools.Field(MonsterBoardTooltipType, "_skillReference")
-            : null;
+    private static readonly FieldInfo? SkillReferenceField = FindMonsterBoardTooltipField(
+        "_skillReference"
+    );
 
-    private static readonly FieldInfo? SocketsField =
-        MonsterBoardTooltipType != null
-            ? AccessTools.Field(MonsterBoardTooltipType, "_sockets")
-            : null;
+    private static readonly FieldInfo? SocketsField = FindMonsterBoardTooltipField("_sockets");
+
+    private static readonly FieldInfo? SmallCardUiAssetRefField = FindAssetLoaderField(
+        "SmallCardUIAssetRef"
+    );
+
+    private static readonly FieldInfo? MediumCardUiAssetRefField = FindAssetLoaderField(
+        "MediumCardUIAssetRef"
+    );
+
+    private static readonly FieldInfo? LargeCardUiAssetRefField = FindAssetLoaderField(
+        "LargeCardUIAssetRef"
+    );
+
+    private static readonly FieldInfo? SkillUiAssetRefField = FindAssetLoaderField(
+        "SkillUIAssetRef"
+    );
 
     public static bool TryGetPrefab(
         NativeCardPreviewKind kind,
@@ -80,21 +93,11 @@ internal static class NativeCardPreviewPrefabResolver
                 return true;
         }
 
-        if (
-            MonsterBoardTooltipType == null
-            || SmallItemReferenceField == null
-            || MediumItemReferenceField == null
-            || LargeItemReferenceField == null
-            || (requireSkill && SkillReferenceField == null)
-            || (requireSockets && SocketsField == null)
-        )
-        {
-            BppLog.Warn(
-                logComponent,
-                $"{MonsterBoardTooltipTypeName} reflection metadata missing; native card preview unavailable on this game version."
-            );
-            return false;
-        }
+        if (TryResolveFromAssetLoader(requireSkill, requireSockets, logComponent))
+            return true;
+
+        if (!HasTooltipMetadata(requireSkill, requireSockets))
+            return LogMissingMetadataOnce(logComponent);
 
         var tooltips = Resources.FindObjectsOfTypeAll(MonsterBoardTooltipType);
         if (tooltips == null || tooltips.Length == 0)
@@ -105,9 +108,9 @@ internal static class NativeCardPreviewPrefabResolver
             if (tooltipObj is not Component tooltip || tooltip == null)
                 continue;
 
-            var small = SmallItemReferenceField.GetValue(tooltip) as Component;
-            var medium = MediumItemReferenceField.GetValue(tooltip) as Component;
-            var large = LargeItemReferenceField.GetValue(tooltip) as Component;
+            var small = SmallItemReferenceField!.GetValue(tooltip) as Component;
+            var medium = MediumItemReferenceField!.GetValue(tooltip) as Component;
+            var large = LargeItemReferenceField!.GetValue(tooltip) as Component;
             var skill = SkillReferenceField?.GetValue(tooltip) as Component;
             var sockets = SocketsField?.GetValue(tooltip) as RectTransform[];
 
@@ -140,6 +143,125 @@ internal static class NativeCardPreviewPrefabResolver
         }
 
         return false;
+    }
+
+    private static bool TryResolveFromAssetLoader(
+        bool requireSkill,
+        bool requireSockets,
+        string logComponent
+    )
+    {
+        if (
+            SmallCardUiAssetRefField == null
+            || MediumCardUiAssetRefField == null
+            || LargeCardUiAssetRefField == null
+            || (requireSkill && SkillUiAssetRefField == null)
+        )
+            return false;
+
+        if (!Services.TryGet<AssetLoader>(out var assetLoader) || assetLoader == null)
+            return false;
+
+        try
+        {
+            var small = LoadPreviewPrefab(assetLoader, SmallCardUiAssetRefField);
+            var medium = LoadPreviewPrefab(assetLoader, MediumCardUiAssetRefField);
+            var large = LoadPreviewPrefab(assetLoader, LargeCardUiAssetRefField);
+            var skill = SkillUiAssetRefField != null
+                ? LoadPreviewPrefab(assetLoader, SkillUiAssetRefField)
+                : null;
+
+            if (
+                small == null
+                || medium == null
+                || large == null
+                || (requireSkill && skill == null)
+                || (requireSockets && (_socketTemplates == null || _socketTemplates.Length == 0))
+            )
+                return false;
+
+            lock (Lock)
+            {
+                PrefabRefs[NativeCardPreviewKind.ForItem(ECardSize.Small)] = small;
+                PrefabRefs[NativeCardPreviewKind.ForItem(ECardSize.Medium)] = medium;
+                PrefabRefs[NativeCardPreviewKind.ForItem(ECardSize.Large)] = large;
+                if (skill != null)
+                    PrefabRefs[NativeCardPreviewKind.ForSkill()] = skill;
+                _resolved = true;
+            }
+
+            BppLog.Info(
+                logComponent,
+                $"Acquired native card preview refs from AssetLoader (small='{small.name}', medium='{medium.name}', large='{large.name}', skill='{skill?.name ?? "(none)"}')."
+            );
+            return true;
+        }
+        catch (System.Exception ex)
+        {
+            if (!_assetLoaderFailureLogged)
+            {
+                _assetLoaderFailureLogged = true;
+                BppLog.Warn(
+                    logComponent,
+                    $"AssetLoader card preview prefab resolution failed: {ex.Message}"
+                );
+            }
+            return false;
+        }
+    }
+
+    private static Component? LoadPreviewPrefab(AssetLoader assetLoader, FieldInfo field)
+    {
+        if (field.GetValue(assetLoader) is not AssetReference assetReference)
+            return null;
+        if (!assetReference.RuntimeKeyIsValid())
+            return null;
+
+        var handle = Addressables.LoadAssetAsync<GameObject>(assetReference);
+        var prefab = handle.WaitForCompletion();
+        if (prefab == null || NativeCardPreviewReflection.CardPreviewBaseType == null)
+            return null;
+
+        return prefab.GetComponent(NativeCardPreviewReflection.CardPreviewBaseType);
+    }
+
+    private static bool HasTooltipMetadata(bool requireSkill, bool requireSockets)
+    {
+        return MonsterBoardTooltipType != null
+            && SmallItemReferenceField != null
+            && MediumItemReferenceField != null
+            && LargeItemReferenceField != null
+            && (!requireSkill || SkillReferenceField != null)
+            && (!requireSockets || SocketsField != null);
+    }
+
+    private static bool LogMissingMetadataOnce(string logComponent)
+    {
+        if (!_missingMetadataLogged)
+        {
+            _missingMetadataLogged = true;
+            BppLog.Warn(
+                logComponent,
+                $"{MonsterBoardTooltipTypeName} and AssetLoader reflection metadata missing; native card preview unavailable on this game version."
+            );
+        }
+        return false;
+    }
+
+    private static FieldInfo? FindMonsterBoardTooltipField(string fieldName)
+    {
+        return MonsterBoardTooltipType?.GetField(
+            fieldName,
+            BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic
+        );
+    }
+
+    private static FieldInfo? FindAssetLoaderField(string fieldName)
+    {
+        return typeof(AssetLoader).GetField(
+            fieldName,
+            BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic
+        );
     }
 
     private static bool HasRequiredRefs(bool requireSkill, bool requireSockets)

--- a/bazaarplusplus-mod/src/BazaarPlusPlus/GameInterop/CardPreview/NativeCardPreviewRuntime.cs
+++ b/bazaarplusplus-mod/src/BazaarPlusPlus/GameInterop/CardPreview/NativeCardPreviewRuntime.cs
@@ -1,6 +1,7 @@
 #nullable enable
 using System;
 using System.Reflection;
+using System.Threading;
 using System.Threading.Tasks;
 using BazaarGameShared.Domain.Cards;
 using BazaarGameShared.Domain.Core.Types;
@@ -80,7 +81,12 @@ internal static class NativeCardPreviewRuntime
 
         try
         {
-            var raw = method.Invoke(card, new object[] { template, false, instance });
+            var parameterCount = method.GetParameters().Length;
+            var parameters =
+                parameterCount >= 4
+                    ? new object[] { template, false, instance, CancellationToken.None }
+                    : new object[] { template, false, instance };
+            var raw = method.Invoke(card, parameters);
             if (raw is Task task)
                 await task;
         }

--- a/bazaarplusplus-mod/src/BazaarPlusPlus/Patches/CollectionPanel/CollectionCardPreviewDestroyPatch.cs
+++ b/bazaarplusplus-mod/src/BazaarPlusPlus/Patches/CollectionPanel/CollectionCardPreviewDestroyPatch.cs
@@ -34,6 +34,7 @@ internal static class CollectionCardPreviewDestroyPatch
             marker.CurrentArtKey = null;
         }
 
-        __instance._cardMaterial = null!;
+        if (materialCache != null && materialCache.Contains(__instance._cardMaterial))
+            __instance._cardMaterial = null!;
     }
 }

--- a/bazaarplusplus-mod/src/BazaarPlusPlus/Patches/CollectionPanel/CollectionItemLoadArtPatch.cs
+++ b/bazaarplusplus-mod/src/BazaarPlusPlus/Patches/CollectionPanel/CollectionItemLoadArtPatch.cs
@@ -25,6 +25,14 @@ internal static class CollectionItemLoadArtPatch
         if (marker == null)
             return true;
 
+        // The game now resolves card art through its AssetLoader rather than direct
+        // Addressables calls. Let the native LoadArt path run so new address-resolution
+        // behavior is preserved; the cache-backed replacement below is intentionally
+        // disabled until it can mirror the native loader exactly again.
+        marker.CurrentArtKey = null;
+        return true;
+
+#pragma warning disable CS0162
         var artCache = CollectionCardCacheHost.ArtCache;
         var materialCache = CollectionCardCacheHost.MaterialCache;
         if (artCache == null || materialCache == null)
@@ -32,6 +40,7 @@ internal static class CollectionItemLoadArtPatch
 
         __result = LoadArtFromCache(__instance, marker, artCache, materialCache);
         return false;
+#pragma warning restore CS0162
     }
 
     private static async Task LoadArtFromCache(


### PR DESCRIPTION
## 问题原因

游戏更新后，卡牌图鉴失效主要有三处原因：

1. 游戏移除了 `MonsterBoardTooltip` 里旧的卡牌预览 prefab 私有字段  
   插件原来通过反射读取 `_smallItemReference`、`_mediumItemReference`、`_largeItemReference`、`_skillReference` 来拿原生卡牌预览 prefab。  
   新版游戏已经不再保留这些字段，导致插件拿不到卡牌 prefab，图鉴只能显示空框。

2. `CardPreviewBase.SetUp` 方法签名变了  
   旧版是 3 个参数，新版新增了 `CancellationToken` 参数。  
   插件仍按旧签名反射调用，导致每张卡初始化时报 `Number of parameters specified does not match the expected number`，卡牌内容无法加载。

3. 新版原生卡牌 prefab 的布局行为变了  
   修复 prefab 和 `SetUp` 后，卡牌虽然能加载，但会以原生尺寸浮在网格上方，不能正确缩放进图鉴格子。  
   原因是新版 `CardPreviewItem.Resize()` 会依赖父级 `RectTransform` 尺寸计算位置，旧插件直接把卡牌挂到大面板下，父级尺寸不再适配单个格子。

## 修复方式

1. 新增 `AssetLoader` prefab 解析兜底  
   当旧的 `MonsterBoardTooltip` 字段不存在时，改为从游戏 `AssetLoader` 的 UI 卡牌引用中获取 prefab：

   - `SmallCardUIAssetRef`
   - `MediumCardUIAssetRef`
   - `LargeCardUIAssetRef`
   - `SkillUIAssetRef`

   这样可以兼容新版游戏的卡牌 UI 加载方式。

2. 兼容新旧 `CardPreviewBase.SetUp` 签名  
   反射调用前检查参数数量：

   - 旧版：传入 `card, isPremium, cardInstance`
   - 新版：传入 `card, isPremium, cardInstance, CancellationToken.None`

   避免游戏更新后因为参数数量变化导致图鉴卡牌初始化失败。

3. 为图鉴每个格子增加独立 `RectTransform` 容器  
   卡牌不再直接挂到整个图鉴面板下，而是先创建一个和图鉴格子同尺寸的容器，再把原生卡牌预览挂进去。  
   容器负责网格定位，游戏原生 `Resize()` 负责卡牌内部布局，插件再做最终缩放，保证卡牌能正确显示在格子内。

4. 放弃覆盖新版原生 `LoadArt` 逻辑  
   图鉴卡牌现在让游戏自己的 `CardPreviewItem.LoadArt` 路径运行，避免插件旧的 Addressables 加载逻辑和新版 `AssetLoader` 解析方式不一致。

5. 构建脚本安全性调整  
   原构建脚本会先删除插件目录里的旧 DLL 再复制新 DLL。  
   如果游戏正在运行导致文件被锁，可能会出现“删了一半但复制失败”的情况，使插件按钮消失。  
   现在默认不再预删除插件文件，只有显式设置 `BppCleanPluginBeforeCopy=true` 时才执行清理。