### PR TITLE
fix: 修复了检测steamdeck状态时卡死的问题

### DIFF
--- a/backend/bpp/decky_adapter.py
+++ b/backend/bpp/decky_adapter.py
@@ -1,5 +1,6 @@
 import asyncio
 from pathlib import Path
+from typing import Optional
 
 import decky
 
@@ -28,11 +29,30 @@ def _latest_to_wire(latest: LatestRelease) -> dict[str, object]:
     }
 
 
+def _log_exception(message: str) -> None:
+    logger = decky.logger
+    exception = getattr(logger, "exception", None)
+    if callable(exception):
+        exception(message)
+        return
+    error = getattr(logger, "error", None)
+    if callable(error):
+        error(message, exc_info=True)
+        return
+    logger.info("%s", message)
+
+
 class Plugin:
     async def _main(self) -> None:
         self._loop = asyncio.get_running_loop()
         runtime_dir = Path(decky.DECKY_PLUGIN_RUNTIME_DIR)
         settings_dir = Path(decky.DECKY_PLUGIN_SETTINGS_DIR)
+        decky.logger.info(
+            "Initializing BazaarPlusPlus plugin runtime=%s settings=%s user_home=%s",
+            runtime_dir,
+            settings_dir,
+            decky.DECKY_USER_HOME,
+        )
         runtime_dir.mkdir(parents=True, exist_ok=True)
         settings_dir.mkdir(parents=True, exist_ok=True)
         releases = OfficialReleaseSource(runtime_dir)
@@ -50,10 +70,35 @@ class Plugin:
         decky.logger.info("BazaarPlusPlus Steam Deck plugin unloaded")
 
     async def get_status(self) -> dict[str, object]:
-        return _status_to_wire(await asyncio.to_thread(self._manager.status))
+        decky.logger.info("Checking BazaarPlusPlus Steam Deck status")
+        try:
+            status = await asyncio.to_thread(self._manager.status)
+        except Exception:
+            _log_exception("Failed to check BazaarPlusPlus Steam Deck status")
+            raise
+        decky.logger.info(
+            "BazaarPlusPlus status game_found=%s installed=%s game_running=%s game_path=%s installed_version=%s",
+            status.game_found,
+            status.installed,
+            status.game_running,
+            status.game_path,
+            status.installed_version,
+        )
+        return _status_to_wire(status)
 
     async def check_latest(self) -> dict[str, object]:
-        return _latest_to_wire(await asyncio.to_thread(self._manager.check_latest))
+        decky.logger.info("Checking latest BazaarPlusPlus release")
+        try:
+            latest = await asyncio.to_thread(self._manager.check_latest)
+        except Exception:
+            _log_exception("Failed to check latest BazaarPlusPlus release")
+            raise
+        decky.logger.info(
+            "Latest BazaarPlusPlus release version=%s update_available=%s",
+            latest.version,
+            latest.update_available,
+        )
+        return _latest_to_wire(latest)
 
     async def install_latest(self) -> dict[str, object]:
         def progress(message: str, percent: int) -> None:
@@ -79,7 +124,7 @@ class Plugin:
     async def remember_launch_options(self, original: str, managed: str) -> None:
         await asyncio.to_thread(self._settings.save, original, managed)
 
-    async def get_launch_options_backup(self) -> dict[str, str] | None:
+    async def get_launch_options_backup(self) -> Optional[dict[str, str]]:
         backup = await asyncio.to_thread(self._settings.get)
         if backup is None:
             return None

--- a/backend/bpp/installer.py
+++ b/backend/bpp/installer.py
@@ -4,7 +4,7 @@ import stat
 import tempfile
 import zipfile
 from pathlib import Path, PurePosixPath
-from typing import Iterable
+from typing import Iterable, Optional
 
 from .models import Release, normalize_version
 from .release import ProgressReporter, ReleaseSource
@@ -136,7 +136,7 @@ def _apply_staged_payload(staging: Path, game_path: Path) -> None:
                 shutil.copy2(source, temporary)
                 os.replace(temporary, destination)
         except Exception as install_error:
-            rollback_error: Exception | None = None
+            rollback_error: Optional[Exception] = None
             for relative in files:
                 destination = _assert_safe_destination(game_path, relative)
                 temporary = destination.with_name(destination.name + ".bpp-new")
@@ -224,7 +224,7 @@ class Installer:
             raise RuntimeError("拒绝删除符号链接形式的数据目录")
         shutil.rmtree(data_path, ignore_errors=True)
 
-    def installed_version(self, game_path: Path) -> str | None:
+    def installed_version(self, game_path: Path) -> Optional[str]:
         version_file = game_path / "BepInEx/plugins/BazaarPlusPlus.version"
         plugin_file = game_path / "BepInEx/plugins/BazaarPlusPlus.dll"
         if not plugin_file.is_file():

--- a/backend/bpp/models.py
+++ b/backend/bpp/models.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from typing import Optional
 
 
 @dataclass(frozen=True)
@@ -10,10 +11,10 @@ class Release:
 @dataclass(frozen=True)
 class PluginStatus:
     game_found: bool
-    game_path: str | None
+    game_path: Optional[str]
     game_running: bool
     installed: bool
-    installed_version: str | None
+    installed_version: Optional[str]
 
 
 @dataclass(frozen=True)

--- a/backend/bpp/release.py
+++ b/backend/bpp/release.py
@@ -10,7 +10,7 @@ import time
 import urllib.parse
 import urllib.request
 from pathlib import Path
-from typing import Any, Callable, Protocol
+from typing import Any, Callable, Optional, Protocol
 
 from .models import Release
 
@@ -193,9 +193,9 @@ def _download(
     url: str,
     destination: Path,
     *,
-    expected_sha256: str | None = None,
-    verify_url: Callable[[str], None] | None = None,
-    progress: Callable[[int], None] | None = None,
+    expected_sha256: Optional[str] = None,
+    verify_url: Optional[Callable[[str], None]] = None,
+    progress: Optional[Callable[[int], None]] = None,
 ) -> Path:
     if (expected_sha256 is None) == (verify_url is None):
         raise RuntimeError("下载必须提供 SHA-256 或 URL 校验器（二选一）")
@@ -316,7 +316,7 @@ class OfficialReleaseSource:
     ) -> None:
         self._runtime_dir = runtime_dir
         self._clock = clock
-        self._cache: tuple[float, Release] | None = None
+        self._cache: Optional[tuple[float, Release]] = None
 
     def latest(self) -> Release:
         now = self._clock()

--- a/backend/bpp/settings.py
+++ b/backend/bpp/settings.py
@@ -2,7 +2,7 @@ import json
 import os
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, Optional
 
 
 MAX_LAUNCH_OPTIONS_LENGTH = 16384
@@ -36,7 +36,7 @@ class LaunchOptionsBackupStore:
             {"original": original, "managed": managed},
         )
 
-    def get(self) -> LaunchOptionsBackup | None:
+    def get(self) -> Optional[LaunchOptionsBackup]:
         try:
             value = json.loads(self._path.read_text("utf-8"))
         except (OSError, json.JSONDecodeError):

--- a/backend/bpp/steam.py
+++ b/backend/bpp/steam.py
@@ -1,6 +1,6 @@
 import re
 from pathlib import Path
-from typing import Protocol
+from typing import Optional, Protocol
 
 
 APP_ID = 1617400
@@ -9,7 +9,7 @@ GAME_EXECUTABLE = "TheBazaar.exe"
 
 
 class SteamEnvironment(Protocol):
-    def find_game(self) -> Path | None: ...
+    def find_game(self) -> Optional[Path]: ...
 
     def is_game_running(self) -> bool: ...
 
@@ -51,7 +51,7 @@ def _steam_roots(user_home: Path) -> list[Path]:
     return discovered
 
 
-def _manifest_install_dir(manifest: Path) -> str | None:
+def _manifest_install_dir(manifest: Path) -> Optional[str]:
     try:
         contents = manifest.read_text("utf-8", errors="replace")
     except OSError:
@@ -65,7 +65,7 @@ class LinuxSteamEnvironment:
         self._user_home = user_home
         self._proc_root = proc_root
 
-    def find_game(self) -> Path | None:
+    def find_game(self) -> Optional[Path]:
         for root in _steam_roots(self._user_home):
             steamapps = root / "steamapps"
             install_dir = _manifest_install_dir(

--- a/main.py
+++ b/main.py
@@ -1,3 +1,8 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
 from backend.bpp.decky_adapter import Plugin
 
 __all__ = ["Plugin"]

--- a/src/features/installer/PluginPanel.tsx
+++ b/src/features/installer/PluginPanel.tsx
@@ -8,12 +8,31 @@ import { useInstaller } from "./useInstaller";
 
 function StatusCard({
   status,
+  statusError,
   latest,
 }: {
   status: PluginStatus | null;
+  statusError: string;
   latest: LatestRelease | null;
 }) {
   if (!status) {
+    if (statusError) {
+      return (
+        <div
+          style={{
+            padding: "10px 12px",
+            borderRadius: 8,
+            background: "rgba(255,90,90,.12)",
+            color: "#ffb4b4",
+            lineHeight: 1.45,
+            wordBreak: "break-word",
+          }}
+        >
+          <div>检测失败</div>
+          <div style={{ opacity: 0.75, fontSize: 11 }}>{statusError}</div>
+        </div>
+      );
+    }
     return <div style={{ opacity: 0.7 }}>正在检测…</div>;
   }
   const stateText = !status.game_found
@@ -46,13 +65,13 @@ function StatusCard({
 
 export function PluginPanel() {
   const controller = useInstaller();
-  const { status, latest, busy, progress, repairMode } = controller;
+  const { status, statusError, latest, busy, progress, repairMode } = controller;
   const updateAvailable = latest?.update_available ?? false;
   return (
     <>
       <PanelSection title="Steam Deck 安装状态">
         <PanelSectionRow>
-          <StatusCard status={status} latest={latest} />
+          <StatusCard status={status} statusError={statusError} latest={latest} />
         </PanelSectionRow>
         {progress && (
           <PanelSectionRow>

--- a/src/features/installer/useInstaller.ts
+++ b/src/features/installer/useInstaller.ts
@@ -24,6 +24,7 @@ const launchOptions = createLaunchOptionsManager(
 
 export type InstallerController = {
   status: PluginStatus | null;
+  statusError: string;
   latest: LatestRelease | null;
   busy: boolean;
   progress: string;
@@ -37,6 +38,7 @@ export type InstallerController = {
 
 export function useInstaller(): InstallerController {
   const [status, setStatus] = useState<PluginStatus | null>(null);
+  const [statusError, setStatusError] = useState("");
   const [latest, setLatest] = useState<LatestRelease | null>(null);
   const [busy, setBusy] = useState(false);
   const [progress, setProgress] = useState("");
@@ -46,6 +48,7 @@ export function useInstaller(): InstallerController {
 
   const refresh = useCallback(async () => {
     try {
+      setStatusError("");
       const next = await refreshInstallerState(backendClient, (error) =>
         console.warn("Unable to check BazaarPlusPlus release", error),
       );
@@ -55,6 +58,7 @@ export function useInstaller(): InstallerController {
         setLatest(next.latest);
       }
     } catch (error) {
+      setStatusError(String(error));
       toaster.toast({
         title: "状态刷新失败",
         body: String(error),
@@ -175,6 +179,7 @@ export function useInstaller(): InstallerController {
 
   return {
     status,
+    statusError,
     latest,
     busy,
     progress,

--- a/tests/backend/fakes.py
+++ b/tests/backend/fakes.py
@@ -1,14 +1,15 @@
 from pathlib import Path
+from typing import Optional
 
 from backend.bpp.models import Release
 
 
 class FakeSteamEnvironment:
-    def __init__(self, game_path: Path | None = None, running: bool = False) -> None:
+    def __init__(self, game_path: Optional[Path] = None, running: bool = False) -> None:
         self.game_path = game_path
         self.running = running
 
-    def find_game(self) -> Path | None:
+    def find_game(self) -> Optional[Path]:
         return self.game_path
 
     def is_game_running(self) -> bool:
@@ -29,7 +30,7 @@ class FakeReleaseSource:
 
 
 class FakeInstaller:
-    def __init__(self, installed_version: str | None = None) -> None:
+    def __init__(self, installed_version: Optional[str] = None) -> None:
         self.version = installed_version
         self.calls: list[tuple[str, Path]] = []
 

--- a/tests/backend/test_architecture.py
+++ b/tests/backend/test_architecture.py
@@ -30,12 +30,40 @@ class ArchitectureRulesTests(unittest.TestCase):
                 if restricted in imports:
                     self.assertIn(path.name, {"installer.py", "release.py"})
 
-    def test_thin_python_and_typescript_entrypoints(self):
+    def test_python_entrypoint_adds_package_dir_before_backend_import(self):
         tree = ast.parse((ROOT / "main.py").read_text("utf-8"))
-        self.assertEqual(len(tree.body), 2)
-        import_node, export_node = tree.body
+        imported_modules = [
+            node.module
+            for node in tree.body
+            if isinstance(node, ast.ImportFrom)
+        ]
+        self.assertIn("pathlib", imported_modules)
+        backend_import_index = next(
+            index
+            for index, node in enumerate(tree.body)
+            if isinstance(node, ast.ImportFrom)
+            and node.module == "backend.bpp.decky_adapter"
+        )
+        path_setup_index = next(
+            index
+            for index, node in enumerate(tree.body)
+            if isinstance(node, ast.Expr)
+            and isinstance(node.value, ast.Call)
+            and isinstance(node.value.func, ast.Attribute)
+            and node.value.func.attr == "insert"
+        )
+        self.assertLess(path_setup_index, backend_import_index)
+
+    def test_python_entrypoint_exports_plugin(self):
+        tree = ast.parse((ROOT / "main.py").read_text("utf-8"))
+        import_node = next(
+            node
+            for node in tree.body
+            if isinstance(node, ast.ImportFrom)
+            and node.module == "backend.bpp.decky_adapter"
+        )
+        export_node = tree.body[-1]
         self.assertIsInstance(import_node, ast.ImportFrom)
-        self.assertEqual(import_node.module, "backend.bpp.decky_adapter")
         self.assertEqual([alias.name for alias in import_node.names], ["Plugin"])
         self.assertIsInstance(export_node, ast.Assign)
         self.assertEqual(

--- a/tests/packaging/bundle_smoke.py
+++ b/tests/packaging/bundle_smoke.py
@@ -35,17 +35,13 @@ def main(zip_path: str) -> None:
 
         decky.emit = emit
         sys.modules["decky"] = decky
-        sys.path.insert(0, str(package))
-        try:
-            spec = importlib.util.spec_from_file_location("bpp_bundle_main", entrypoint)
-            if spec is None or spec.loader is None:
-                raise SystemExit("cannot create bundle main.py import spec")
-            module = importlib.util.module_from_spec(spec)
-            spec.loader.exec_module(module)
-            if not isinstance(getattr(module, "Plugin", None), type):
-                raise SystemExit("bundle main.py does not expose Plugin")
-        finally:
-            sys.path.remove(str(package))
+        spec = importlib.util.spec_from_file_location("bpp_bundle_main", entrypoint)
+        if spec is None or spec.loader is None:
+            raise SystemExit("cannot create bundle main.py import spec")
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        if not isinstance(getattr(module, "Plugin", None), type):
+            raise SystemExit("bundle main.py does not expose Plugin")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
在测试您从原仓库向我fork后的仓库发起的[PR](https://github.com/VIkill33/BazaarPlusPlusForSteamDeck/pull/1)时，发现问题：
- steamdeck上加载插件后，会一直卡在“检测中...“的状态。

请review并合并我的这条修复PR，之后我再approve您的原pr。



> 以下为codex对本次修复的说明：

> 这次改动修复了 Decky 插件安装后设置页一直停留在“正在检测…”的问题。原因是插件 zip 中的 main.py 加载后端包时没有把插件目录加入 Python import path，导致 Decky 后端入口无法导入 backend 包，RPC 没有注册。
> 修复内容包括：
> 在 main.py 中先加入插件目录到 sys.path，确保 zip 安装环境下能加载后端包
> 增加后端 Python 3.9 兼容性，避免旧运行时因类型标注导入失败
> 增加 Decky 后端状态检测日志，方便后续定位问题
> 前端在状态刷新失败时显示错误，不再无限停留在“正在检测…”
> 更新打包 smoke test，模拟真实 zip 加载场景，防止同类问题再次漏测