### PR TITLE
fix(installer): accept uppercase Steam Apps key

### DIFF
--- a/bazaarplusplus-installer/src-tauri/src/services/vdf/parse.rs
+++ b/bazaarplusplus-installer/src-tauri/src/services/vdf/parse.rs
@@ -100,7 +100,9 @@ fn join_lines(lines: &[String]) -> String {
 }
 
 fn find_apps_block(lines: &[String]) -> Option<(usize, usize)> {
-    let start = lines.iter().position(|line| line.trim() == "\"apps\"")?;
+    let start = lines
+        .iter()
+        .position(|line| line.trim().eq_ignore_ascii_case("\"apps\""))?;
     let open = (start + 1..lines.len()).find(|&idx| lines[idx].trim() == "{")?;
     let mut depth = 0usize;
 

--- a/bazaarplusplus-installer/src-tauri/src/services/vdf/tests.rs
+++ b/bazaarplusplus-installer/src-tauri/src/services/vdf/tests.rs
@@ -41,6 +41,22 @@ fn test_inject_launch_options_inserts_when_missing() {
 }
 
 #[test]
+fn test_launch_options_supports_uppercase_apps_key() {
+    let vdf = fixture_vdf().replace("\"apps\"", "\"Apps\"");
+    let args = "MY_ARGS";
+
+    let rendered = inject_launch_options(&vdf, args).unwrap().unwrap();
+    assert!(rendered.contains("\"Apps\""));
+    assert_eq!(
+        verify_launch_options_in_content(&rendered, args).unwrap(),
+        Some(true)
+    );
+
+    let cleared = clear_launch_options(&rendered).unwrap().unwrap();
+    assert!(!cleared.contains("LaunchOptions"));
+}
+
+#[test]
 fn test_inject_launch_options_replaces_existing() {
     let vdf_with_lo = fixture_vdf().replace(
         "\"LastPlayed\"",


### PR DESCRIPTION
## Summary

- match the Steam `apps` VDF block case-insensitively
- add regression coverage for install, verification, and cleanup with an uppercase `Apps` key

## Root cause

Steam may serialize the block in `userdata/<account>/config/localconfig.vdf` as `Software/Valve/Steam/Apps`. The installer searched for the exact lowercase line `"apps"`, so it failed with:

```text
Malformed VDF: could not locate Steam/apps object
```

The payload had already been copied before `LaunchOptions` was patched. On the next installer launch, file-based detection could therefore report BazaarPlusPlus as installed even though Steam still launched the vanilla game.

## Temporary workaround

Until this fix is released, macOS users can open **Steam > The Bazaar > Properties > Launch Options** and set:

```text
"/Users/<username>/Library/Application Support/Steam/steamapps/common/The Bazaar/run_bepinex.sh" %command%
```

Use the actual game installation path if it differs from Steam's default path.

## Testing

- `cargo fmt --manifest-path src-tauri/Cargo.toml --check`
- `cargo test --manifest-path src-tauri/Cargo.toml services::vdf::tests` (13 passed)
- `cargo test --manifest-path src-tauri/Cargo.toml` (153 passed)
