### PR TITLE
perf(post-combat-impact): 批量结算原生预览布局

### DIFF
--- a/bazaarplusplus-mod/src/BazaarPlusPlus/GameInterop/CardPreview/NativeCardPreviewSlotFitter.cs
+++ b/bazaarplusplus-mod/src/BazaarPlusPlus/GameInterop/CardPreview/NativeCardPreviewSlotFitter.cs
@@ -15,8 +15,23 @@ internal static class NativeCardPreviewSlotFitter
             return NativeCardPreviewSlotFitResult.Unavailable;
 
         Canvas.ForceUpdateCanvases();
+        return FitWithSettledCanvas(preview, slot, horizontalAlignment, new Vector3[4]);
+    }
+
+    /// <summary>
+    /// Fits one preview after the caller has settled the Canvas shared by a larger layout batch.
+    /// </summary>
+    internal static NativeCardPreviewSlotFitResult FitWithSettledCanvas(
+        RectTransform preview,
+        RectTransform slot,
+        NativeCardPreviewHorizontalAlignment horizontalAlignment,
+        Vector3[] corners
+    )
+    {
+        if (preview == null || slot == null || corners == null || corners.Length < 4)
+            return NativeCardPreviewSlotFitResult.Unavailable;
+
         var frame = FindDescendant(preview, "FrameContainer") ?? preview;
-        var corners = new Vector3[4];
         frame.GetWorldCorners(corners);
         var minX = float.PositiveInfinity;
         var minY = float.PositiveInfinity;
@@ -67,6 +82,29 @@ internal static class NativeCardPreviewSlotFitter
             return false;
 
         Canvas.ForceUpdateCanvases();
+        return TryAlignVisibleArtworkLeftWithSettledCanvas(
+            preview,
+            slot,
+            new Vector3[4],
+            out visibleWidth
+        );
+    }
+
+    /// <summary>
+    /// Aligns visible artwork after the caller has settled the Canvas shared by a larger layout
+    /// batch.
+    /// </summary>
+    internal static bool TryAlignVisibleArtworkLeftWithSettledCanvas(
+        RectTransform preview,
+        RectTransform slot,
+        Vector3[] corners,
+        out float visibleWidth
+    )
+    {
+        visibleWidth = 0f;
+        if (preview == null || slot == null || corners == null || corners.Length < 4)
+            return false;
+
         // CardPreviewItem.Resize offsets wider cards inside their root, while the native frame
         // prefab itself can carry transparent horizontal inset. Align the actual artwork quad,
         // which is the stable visible seam shared by Small/Medium/Large previews, instead of the
@@ -74,7 +112,6 @@ internal static class NativeCardPreviewSlotFitter
         var frame = FindNativeArtwork(preview);
         if (frame == null)
             return false;
-        var corners = new Vector3[4];
         frame.GetWorldCorners(corners);
         var visibleMinX = float.PositiveInfinity;
         var visibleMaxX = float.NegativeInfinity;

--- a/bazaarplusplus-mod/src/BazaarPlusPlus/Patches/PostCombatImpact/NativePostCombatImpactTooltipView.cs
+++ b/bazaarplusplus-mod/src/BazaarPlusPlus/Patches/PostCombatImpact/NativePostCombatImpactTooltipView.cs
@@ -67,6 +67,8 @@ internal sealed class NativePostCombatImpactTooltipView : IPostCombatImpactToolt
     private readonly NativePairedTooltipSession _session;
     private readonly List<LayoutElement> _metricColumns = [];
     private readonly List<INativeCardPreviewSession> _previewSessions = [];
+    private readonly List<PendingNativePreviewFit> _pendingNativePreviewFits = [];
+    private readonly Vector3[] _nativePreviewFitCorners = new Vector3[4];
     private readonly List<ImpactContentBlock> _causedBlocks = [];
     private readonly List<ImpactContentBlock> _receivedBlocks = [];
     private GameObject? _contentRoot;
@@ -88,6 +90,7 @@ internal sealed class NativePostCombatImpactTooltipView : IPostCombatImpactToolt
     private bool _causedPerspectiveBuilt;
     private bool _receivedPerspectiveBuilt;
     private bool _isSkill;
+    private bool _nativePreviewFitFlushScheduled;
     private int _pendingPreviewCount;
     private int _contentGeneration;
     private CombatImpactPerspective _activePerspective = CombatImpactPerspective.Caused;
@@ -434,6 +437,8 @@ internal sealed class NativePostCombatImpactTooltipView : IPostCombatImpactToolt
 
     private void DisposeNativePreviews()
     {
+        _nativePreviewFitFlushScheduled = false;
+        _pendingNativePreviewFits.Clear();
         if (_previewCancellation != null)
         {
             try
@@ -1158,6 +1163,7 @@ internal sealed class NativePostCombatImpactTooltipView : IPostCombatImpactToolt
         CancellationToken cancellationToken
     )
     {
+        var fitQueued = false;
         try
         {
             var outcome = await scope.AcquireAsync(subject, cancellationToken);
@@ -1190,37 +1196,12 @@ internal sealed class NativePostCombatImpactTooltipView : IPostCombatImpactToolt
                 return;
             }
 
-            if (
-                session.FitInto(slot, NativeCardPreviewHorizontalAlignment.Left)
-                != NativeCardPreviewSlotFitResult.Applied
-            )
-            {
-                session.Dispose();
-                HidePreviewSlot(slot);
-                return;
-            }
-
-            if (
-                !NativeCardPreviewSlotFitter.TryAlignVisibleArtworkLeft(
-                    session.Rect,
-                    slot,
-                    out var visibleWidth
-                ) || !FitPreviewColumnToVisibleWidth(slot, visibleWidth, trailingPadding)
-            )
-            {
-                session.Dispose();
-                HidePreviewSlot(slot);
-                BppLog.WarnEvent(
-                    PostCombatImpactLogEvents.InteractionDegraded,
-                    PostCombatImpactLogEvents.ReasonCode.Bind(
-                        PostCombatImpactReasonCode.EntityPreviewUnavailable
-                    )
-                );
-                return;
-            }
-
             _previewSessions.Add(session);
-            owner.Reveal(session.Root);
+            _pendingNativePreviewFits.Add(
+                new PendingNativePreviewFit(session, owner, slot, trailingPadding)
+            );
+            fitQueued = true;
+            ScheduleNativePreviewFitFlush(generation);
         }
         catch (OperationCanceledException)
         {
@@ -1239,9 +1220,176 @@ internal sealed class NativePostCombatImpactTooltipView : IPostCombatImpactToolt
         }
         finally
         {
-            if (generation == _session.Generation)
-                _pendingPreviewCount = Mathf.Max(0, _pendingPreviewCount - 1);
+            if (!fitQueued)
+                CompletePendingPreviews(generation, 1);
         }
+    }
+
+    /// <summary>
+    /// Coalesces native previews that finish acquisition in the same Unity synchronization-context
+    /// turn. The outer presentation still counts each queued preview as pending until this batch has
+    /// completed, so it cannot reveal geometry that has not been fitted yet.
+    /// </summary>
+    private void ScheduleNativePreviewFitFlush(int generation)
+    {
+        if (_nativePreviewFitFlushScheduled)
+            return;
+
+        _nativePreviewFitFlushScheduled = true;
+        _ = FlushNativePreviewFits(generation);
+    }
+
+    private async Task FlushNativePreviewFits(int generation)
+    {
+        await Task.Yield();
+        if (generation != _session.Generation)
+            return;
+
+        _nativePreviewFitFlushScheduled = false;
+        if (_pendingNativePreviewFits.Count == 0)
+            return;
+
+        var batch = _pendingNativePreviewFits.ToArray();
+        _pendingNativePreviewFits.Clear();
+        try
+        {
+            FitNativePreviewBatch(batch);
+        }
+        finally
+        {
+            CompletePendingPreviews(generation, batch.Length);
+        }
+    }
+
+    private void FitNativePreviewBatch(PendingNativePreviewFit[] batch)
+    {
+        try
+        {
+            Canvas.ForceUpdateCanvases();
+        }
+        catch (Exception ex)
+        {
+            foreach (var pending in batch)
+                RejectNativePreview(pending, reportFailure: true, exception: ex);
+            return;
+        }
+
+        var fittedCount = 0;
+        for (var index = 0; index < batch.Length; index++)
+        {
+            var pending = batch[index];
+            try
+            {
+                pending.FitApplied =
+                    NativeCardPreviewSlotFitter.FitWithSettledCanvas(
+                        pending.Session.Rect,
+                        pending.Slot,
+                        NativeCardPreviewHorizontalAlignment.Left,
+                        _nativePreviewFitCorners
+                    ) == NativeCardPreviewSlotFitResult.Applied;
+                batch[index] = pending;
+                if (pending.FitApplied)
+                {
+                    fittedCount++;
+                    continue;
+                }
+
+                RejectNativePreview(pending, reportFailure: false);
+            }
+            catch (Exception ex)
+            {
+                RejectNativePreview(pending, reportFailure: true, exception: ex);
+            }
+        }
+
+        if (fittedCount == 0)
+            return;
+
+        try
+        {
+            Canvas.ForceUpdateCanvases();
+        }
+        catch (Exception ex)
+        {
+            foreach (var pending in batch)
+            {
+                if (pending.FitApplied)
+                    RejectNativePreview(pending, reportFailure: true, exception: ex);
+            }
+            return;
+        }
+
+        foreach (var pending in batch)
+        {
+            if (!pending.FitApplied)
+                continue;
+
+            try
+            {
+                if (
+                    !NativeCardPreviewSlotFitter.TryAlignVisibleArtworkLeftWithSettledCanvas(
+                        pending.Session.Rect,
+                        pending.Slot,
+                        _nativePreviewFitCorners,
+                        out var visibleWidth
+                    )
+                    || !FitPreviewColumnToVisibleWidth(
+                        pending.Slot,
+                        visibleWidth,
+                        pending.TrailingPadding
+                    )
+                )
+                {
+                    RejectNativePreview(pending, reportFailure: true);
+                    continue;
+                }
+
+                pending.Owner.Reveal(pending.Session.Root);
+            }
+            catch (Exception ex)
+            {
+                RejectNativePreview(pending, reportFailure: true, exception: ex);
+            }
+        }
+    }
+
+    private void RejectNativePreview(
+        PendingNativePreviewFit pending,
+        bool reportFailure,
+        Exception? exception = null
+    )
+    {
+        var disposed = false;
+        try
+        {
+            pending.Session.Dispose();
+            disposed = true;
+        }
+        catch (Exception ex)
+        {
+            exception ??= ex;
+            reportFailure = true;
+        }
+        if (disposed)
+            _previewSessions.Remove(pending.Session);
+
+        HidePreviewSlot(pending.Slot);
+        if (!reportFailure)
+            return;
+
+        var reason = PostCombatImpactLogEvents.ReasonCode.Bind(
+            PostCombatImpactReasonCode.EntityPreviewUnavailable
+        );
+        if (exception == null)
+            BppLog.WarnEvent(PostCombatImpactLogEvents.InteractionDegraded, reason);
+        else
+            BppLog.WarnEvent(PostCombatImpactLogEvents.InteractionDegraded, exception, reason);
+    }
+
+    private void CompletePendingPreviews(int generation, int count)
+    {
+        if (generation == _session.Generation)
+            _pendingPreviewCount = Mathf.Max(0, _pendingPreviewCount - Mathf.Max(0, count));
     }
 
     private async Task LoadHero(Image image, RectTransform slot, EHero hero, int generation)
@@ -1273,8 +1421,7 @@ internal sealed class NativePostCombatImpactTooltipView : IPostCombatImpactToolt
         }
         finally
         {
-            if (generation == _session.Generation)
-                _pendingPreviewCount = Mathf.Max(0, _pendingPreviewCount - 1);
+            CompletePendingPreviews(generation, 1);
         }
     }
 
@@ -1574,6 +1721,28 @@ internal sealed class NativePostCombatImpactTooltipView : IPostCombatImpactToolt
             foreach (var row in DetailRows)
                 row.SetActive(true);
         }
+    }
+
+    private struct PendingNativePreviewFit
+    {
+        internal PendingNativePreviewFit(
+            INativeCardPreviewSession session,
+            NativePreviewOwner owner,
+            RectTransform slot,
+            float trailingPadding
+        )
+        {
+            Session = session;
+            Owner = owner;
+            Slot = slot;
+            TrailingPadding = trailingPadding;
+        }
+
+        internal INativeCardPreviewSession Session { get; }
+        internal NativePreviewOwner Owner { get; }
+        internal RectTransform Slot { get; }
+        internal float TrailingPadding { get; }
+        internal bool FitApplied { get; set; }
     }
 
     private sealed class NativePreviewOwner : INativeCardPreviewOwner


### PR DESCRIPTION
Closes #56

## 改动摘要

- 为原生预览 fitting 和可见 artwork 对齐增加“Canvas 已由调用方统一结算”的内部入口
- 合并同一 Unity synchronization-context 轮次内完成的预览 acquisition
- 每批执行两次全局 Canvas 结算，替代每个预览分别执行两次
- 在 Tooltip View 生命周期内复用一个 `Vector3[4]` corner buffer
- 保留现有单预览 API 的结算行为，其他调用方不受影响

## 行为保障

已准备的预览会继续保持隐藏并计入 pending，直到所属批次完成 fitting；presentation 不会提前显示
尚未排版的几何。

异步 acquisition 仍然是渐进式的：实现只合并同一调度轮次内已经完成的预览，不会等待最慢的预览。
每批最多增加一个 synchronization-context 轮次的延迟。

失败仍按单个预览隔离。失败预览会释放 Session 并隐藏对应列，不会阻止同一批次中的成功预览。
Cancellation、generation replacement 和 Session 所有权边界保持不变。

## 验证

- 对两个改动文件执行仓库固定版本的 CSharpier 检查
- 使用本机 The Bazaar Managed assemblies 执行 Debug 构建
- 构建显式设置 `BppDeployToGame=false`
- 构建结果：0 warnings / 0 errors
- `git diff --check`

## 公共源码快照限制

当前公共快照没有包含 `run.sh test` 引用的 `tests/` 目录；`run.sh` 本身也会拒绝 Linux。
因此格式检查和编译通过仓库固定的工具及等价 MSBuild 参数直接执行。

全仓 CSharpier 检查还会报告一个本 PR 未修改的既有文件：
`CollectionPanelView.Tree.cs`。本 PR 修改的两个文件均通过独立格式检查。

## 视觉变更

无预期视觉变更。

BazaarPlusPlus 自身的游戏内视觉和性能验证尚未执行，作为当前已知的验证缺口如实保留，
不影响对实现方案和代码的审查。
